### PR TITLE
F34 reworked CUDA installation method

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 <h1 align="center">nvidia-auto-installer-for-fedora</h1>
-<p align="center">v0.3.5 (23 September 2020) (COPR pending) and v0.3.0 (04 June 2020) (Executable binary)</p>
 <p align="center">A CLI tool which lets you install proprietary NVIDIA drivers and much more easily on Fedora 32 and above</p>
 
 <p align="center">

--- a/nvautoinstall.spec
+++ b/nvautoinstall.spec
@@ -1,7 +1,7 @@
 %global srcname nvidia-auto-installer-for-fedora
 
 Name: nvautoinstall
-Version: 0.3.5
+Version: 0.3.6
 Release: 0%{?dist}
 Summary: NVIDIA Auto Installer for Fedora
 
@@ -36,6 +36,10 @@ A CLI tool which lets you install proprietary NVIDIA drivers and much more
 
 #-- CHANGELOG -----------------------------------------------------------------#
 %changelog
+* Sun May 09 2021 Akashdeep Dhar <t0xic0der@fedoraproject.org>
+- v0.3.6
+- Reworked installation method for CUDA repo compatibility
+- Minor patch leading to a version bump
 * Thu Apr 29 2021 Akashdeep Dhar <t0xic0der@fedoraproject.org>
 - v0.3.5
 - Corrected unicode escape sequences for colors

--- a/src/nvautoinstall/MainFunction.py
+++ b/src/nvautoinstall/MainFunction.py
@@ -146,6 +146,10 @@ class CollPlCudaInstaller(object):
         exec_status_code = os.system("dnf install -y xorg-x11-drv-nvidia-cuda")
         return exec_status_code == 0
 
+    def stop(self):
+        exec_status_code = os.system("dnf module disable -y nvidia-driver")
+        return exec_status_code == 0
+
     def main(self):
         exec_status_code = os.system("dnf install -y cuda")
         return exec_status_code == 0
@@ -321,6 +325,11 @@ class InstallationMode(object):
                         DecoratorObject.section_heading("REFRESHING REPOSITORY LIST...")
                         if PlCudaInstaller.rpup():
                             DecoratorObject.success_message("Repositories have been refreshed")
+                            DecoratorObject.section_heading("DISABLING NVIDIA DRIVER MODULE...")
+                            if PlCudaInstaller.stop():
+                                DecoratorObject.success_message("NVIDIA DRIVER module has been disabled")
+                            else:
+                                DecoratorObject.failure_message("NVIDIA DRIVER module could not be disabled")
                         else:
                             DecoratorObject.failure_message("Repositories could not be refreshed")
                     else:

--- a/src/nvautoinstall/__init__.py
+++ b/src/nvautoinstall/__init__.py
@@ -15,4 +15,4 @@
 # You should have received a copy of the GNU General Public License
 # along with nvautoinstall.  If not, see <https://www.gnu.org/licenses/>.
 
-__version__ = '0.3.5'
+__version__ = '0.3.6'


### PR DESCRIPTION
With F34 (or around that time), it is now required to disable `nvidia-driver` module in order for the CUDA repo to work properly. This can be supported by a section of the official RPM Fusion documentation for CUDA (which you can find [here](https://github.com/t0xic0der/nvidia-auto-installer-for-fedora/issues/55)), discussions up at one of the issues (which you can find [here](https://github.com/t0xic0der/nvidia-auto-installer-for-fedora/issues/55)) and has been talked about in one of the topics up at Ask Fedora (which you can find [here](https://ask.fedoraproject.org/t/solution-modular-filtering-issue-for-nvidia-drivers-cuda-sources-conflict/14063)).

![image](https://user-images.githubusercontent.com/49605954/117579881-a6bf1380-b112-11eb-821a-5fb64a1edb93.png)

![image](https://user-images.githubusercontent.com/49605954/117579897-bcccd400-b112-11eb-9302-d63d9d939061.png)

The following is a test run, which does the following things in succession.

1. Check for elevated privileges
2. Check if the official CUDA repositories are already enabled
3. Ping the official NVIDIA servers to check if they are accessible
4. Install official CUDA repository (Here, `cuda-fedora33.repo`)
5. Refresh repository lists
5. **Disable `nvidia-driver` module**
6. Exit out from the installer

![nvidia-driver](https://user-images.githubusercontent.com/49605954/117579675-9ce8e080-b111-11eb-8292-248d8b01c0bb.png)

CC @kwizart @boistordu