### PR TITLE
Fix distro identification

### DIFF
--- a/src/nvautoinstall/MainFunction.py
+++ b/src/nvautoinstall/MainFunction.py
@@ -93,7 +93,7 @@ class CollSupportCheck(object):
 
     def avbl(self):
         try:
-            if str(distro.os_release_info()["name"]) == "Fedora":
+            if distro.id() == "fedora":
                 if int(distro.os_release_info()["version_id"]) >= 32:
                     return "full"
                 else:


### PR DESCRIPTION
[The NAME field will be "Fedora Linux"](https://fedoraproject.org/wiki/Changes/Fedora_Linux_in_os-release) instead of "Fedora" on Fedora Linux 35. The NAME field is not [suitable for processing by scripts](https://www.freedesktop.org/software/systemd/man/os-release.html#ID=).

> This field is meant for display use. The field ID is meant for scripted use, and will remain fedora. Please check your scripts to make sure they are using the proper field.

![image](https://user-images.githubusercontent.com/66979446/132937354-cd30fd71-9d36-422f-8f36-d39da71e0af5.png)
