### PR TITLE
WIP - initial cuda repos fedora version selection method added

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ Active internet connection and superuser privilege is required to execute the fo
   This mode enables the RPM Fusion NVIDIA drivers repository.
 - **`sudo nvautoinstall driver`**  
   This mode simply installs the NVIDIA drivers. Enabling the RPM Fusion NVIDIA drivers repository is mandatory before 
-  doing this.
-- **`sudo nvautoinstall nvrepo`**  
+  doing this.(Acceptable fedora repo versions are f33-34-35-36)
+- **`sudo nvautoinstall nvrepo f36`**  
   This mode enables the official NVIDIA repository for CUDA software.
 - **`sudo nvautoinstall plcuda`**  
   This mode installs only the CUDA support softwares. Enabling the RPM Fusion NVIDIA drivers and NVIDIA official 

--- a/nvautoinstall/interfaces/install_nvidia_repositories.py
+++ b/nvautoinstall/interfaces/install_nvidia_repositories.py
@@ -31,7 +31,23 @@ from . import (
 
 
 class InstallNvidiaRepositories:
-    def __init__(self):
+    def __init__(self, repover: str):
+        self.repovers = [
+            "f32",
+            "F32",
+            "f33",
+            "F33",
+            "f34",
+            "F34",
+            "f35",
+            "F35",
+            "f36",
+            "F36",
+        ]
+        if repover not in self.repovers:
+            warning("Invalid fedora version argument")
+            general("Example usage: \n  sudo nvautoinstall nvrepo f36")
+            sys.exit(0)
         section("CHECKING SUPERUSER PERMISSIONS...")
         if Objc_CheckSuperuserPermissions.main():
             success("Superuser privilege acquired")
@@ -39,7 +55,9 @@ class InstallNvidiaRepositories:
             if Objc_HandleCudaInstallation.rpck():
                 warning("Official CUDA repository was detected")
                 general(
-                    "Please try executing `nvautoinstall plcuda` with elevated privileges now to install CUDA software"  # noqa
+                    "Please try executing \
+                    `nvautoinstall plcuda` with \
+                    elevated privileges now to install CUDA software"
                 )
                 success("No further action is necessary")
             else:
@@ -49,7 +67,7 @@ class InstallNvidiaRepositories:
                 if Objc_HandleCudaInstallation.conn():
                     success("Connection to NVIDIA servers was established")
                     section("INSTALLING OFFICIAL CUDA REPOSITORY...")
-                    if Objc_HandleCudaInstallation.rpin():
+                    if Objc_HandleCudaInstallation.rpin(repover):
                         success("Official CUDA repository was enabled")
                         section("REFRESHING REPOSITORY LIST...")
                         if Objc_HandleCudaInstallation.rpup():
@@ -58,27 +76,32 @@ class InstallNvidiaRepositories:
                             if Objc_HandleCudaInstallation.stop():
                                 success("NVIDIA DRIVER module has been disabled")
                                 general(
-                                    "Please try executing `nvautoinstall plcuda` with elevated privileges now to install CUDA software"  # noqa
+                                    "Please try executing `nvautoinstall plcuda` with \
+                                        elevated privileges now to install CUDA software"
                                 )
                             else:
                                 failure("NVIDIA DRIVER module could not be disabled")
                                 general(
-                                    "Please try executing `dnf update` with elevated privileges before this"  # noqa
+                                    "Please try executing `dnf update` with \
+                                        elevated privileges before this"
                                 )
                         else:
                             failure("Repositories could not be refreshed")
                             general(
-                                "Please try executing `dnf update` with elevated privileges before this"  # noqa
+                                "Please try executing `dnf update` with \
+                                    elevated privileges before this"
                             )
                     else:
                         failure("Official CUDA repository could not be enabled")
                         general(
-                            "Please try executing `dnf update` with elevated privileges before this"
+                            "Please try executing `dnf update` with \
+                                elevated privileges before this"
                         )
                 else:
                     failure("Connection to NVIDIA servers could not be established")
                     general(
-                        "Please check the internet connection or firewall configuration and try again"  # noqa
+                        "Please check the internet connection or \
+                            firewall configuration and try again"
                     )
         else:
             failure("Superuser privilege could not be acquired")

--- a/nvautoinstall/main.py
+++ b/nvautoinstall/main.py
@@ -59,8 +59,9 @@ def handle_driver_installation():
 
 
 @main.command(name="nvrepo", help="Enable the official NVIDIA repository for CUDA.")
-def install_nvidia_repositories():
-    InstallNvidiaRepositories()
+@click.argument("repover", nargs=1)
+def install_nvidia_repositories(repover):
+    InstallNvidiaRepositories(repover)
 
 
 @main.command(name="plcuda", help="Install only the CUDA support software.")

--- a/nvautoinstall/main.py
+++ b/nvautoinstall/main.py
@@ -58,7 +58,7 @@ def handle_driver_installation():
     HandleDriverInstallation()
 
 
-@main.command(name="nvrepo", help="Enable the official NVIDIA repository for CUDA.")
+@main.command(name="nvrepo", help="Enable NVIDIA repository for CUDA (E.g nvautoinstall nvrepo f36).")
 @click.argument("repover", nargs=1)
 def install_nvidia_repositories(repover):
     InstallNvidiaRepositories(repover)

--- a/nvautoinstall/main.py
+++ b/nvautoinstall/main.py
@@ -58,7 +58,9 @@ def handle_driver_installation():
     HandleDriverInstallation()
 
 
-@main.command(name="nvrepo", help="Enable NVIDIA repository for CUDA (E.g nvautoinstall nvrepo f36).")
+@main.command(
+    name="nvrepo", help="Enable NVIDIA repository for CUDA (E.g nvautoinstall nvrepo f36)."
+)
 @click.argument("repover", nargs=1)
 def install_nvidia_repositories(repover):
     InstallNvidiaRepositories(repover)

--- a/nvautoinstall/operations/handle_cuda_installation.py
+++ b/nvautoinstall/operations/handle_cuda_installation.py
@@ -30,9 +30,9 @@ class HandleCudaInstallation(object):
         output = prompt.communicate()[0].decode("utf-8")
         return "cuda" in output
 
-    def rpin(self):
+    def rpin(self, repover):
         retndata = subprocess.getstatusoutput(
-            "dnf config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/fedora35/x86_64/cuda-fedora35.repo"  # noqa
+            f"dnf config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/fedora{repover[1:]}/x86_64/cuda-fedora{repover[1:]}.repo"  # noqa
         )[0]
         return retndata == 0
 


### PR DESCRIPTION

This also beginning of fixing : https://github.com/t0xic0der/nvidia-auto-installer-for-fedora-linux/issues/65

We can install multiple version of cuda repos and latest driver will be exist, and as for the cuda libs itself, They can co-exists so won't be a problem at all.

Signed-off-by: Onuralp SEZER <thunderbirdtr@fedoraproject.org>